### PR TITLE
jsx comments not needed in react 0.12

### DIFF
--- a/public/js/app.jsx
+++ b/public/js/app.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 import React from 'react'
 import Test from './test'
 

--- a/public/js/test.jsx
+++ b/public/js/test.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 import React from 'react'
 
 // var React = require('react')


### PR DESCRIPTION
FYI the `/*@jsx */` comment is no longer needed
